### PR TITLE
Set predicted recall to zero for docs without predicted labels

### DIFF
--- a/qualle/__init__.py
+++ b/qualle/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/evaluate.py
+++ b/qualle/evaluate.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/__init__.py
+++ b/qualle/features/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/base.py
+++ b/qualle/features/base.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/combined.py
+++ b/qualle/features/combined.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/confidence.py
+++ b/qualle/features/confidence.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/label_calibration/__init__.py
+++ b/qualle/features/label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/label_calibration/base.py
+++ b/qualle/features/label_calibration/base.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/label_calibration/simple_label_calibration.py
+++ b/qualle/features/label_calibration/simple_label_calibration.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/label_calibration/thesauri_label_calibration.py
+++ b/qualle/features/label_calibration/thesauri_label_calibration.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/features/text.py
+++ b/qualle/features/text.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/interface/__init__.py
+++ b/qualle/interface/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/interface/cli.py
+++ b/qualle/interface/cli.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/interface/config.py
+++ b/qualle/interface/config.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/interface/internal.py
+++ b/qualle/interface/internal.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/interface/rest.py
+++ b/qualle/interface/rest.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/label_calibration/__init__.py
+++ b/qualle/label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/label_calibration/category.py
+++ b/qualle/label_calibration/category.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/label_calibration/simple.py
+++ b/qualle/label_calibration/simple.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/main.py
+++ b/qualle/main.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/models.py
+++ b/qualle/models.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/pipeline.py
+++ b/qualle/pipeline.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/quality_estimation.py
+++ b/qualle/quality_estimation.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/train.py
+++ b/qualle/train.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/qualle/utils.py
+++ b/qualle/utils.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/__init__.py
+++ b/tests/features/label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_simple_label_calibration/__init__.py
+++ b/tests/features/label_calibration/test_simple_label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_simple_label_calibration/test_calibrator.py
+++ b/tests/features/label_calibration/test_simple_label_calibration/test_calibrator.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_simple_label_calibration/test_features.py
+++ b/tests/features/label_calibration/test_simple_label_calibration/test_features.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/__init__.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/common.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/common.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/conftest.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/conftest.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/test_calibrator.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/test_calibrator.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/test_features.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/test_features.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/label_calibration/test_thesauri_label_calibration/test_transformer.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/test_transformer.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/test_combined.py
+++ b/tests/features/test_combined.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/test_confidence.py
+++ b/tests/features/test_confidence.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/features/test_text.py
+++ b/tests/features/test_text.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/interface/__init__.py
+++ b/tests/interface/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/interface/common.py
+++ b/tests/interface/common.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/interface/test_cli.py
+++ b/tests/interface/test_cli.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/interface/test_internal.py
+++ b/tests/interface/test_internal.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/interface/test_rest.py
+++ b/tests/interface/test_rest.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/label_calibration/__init__.py
+++ b/tests/label_calibration/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/label_calibration/conftest.py
+++ b/tests/label_calibration/conftest.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/label_calibration/test_category.py
+++ b/tests/label_calibration/test_category.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/label_calibration/test_simple.py
+++ b/tests/label_calibration/test_simple.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_qe.py
+++ b/tests/test_qe.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 ZBW – Leibniz Information Centre for Economics
+#  Copyright 2021-2022 ZBW – Leibniz Information Centre for Economics
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
It is currently ([v.0.1.0](https://github.com/zbw/qualle/releases/tag/v0.1.0)) possible for a document with null predicted labels to receive a non-zero recall prediction from Qualle. By definition, for a document with null predicted labels, the recall can only be null. This PR fixes this by bypassing the predictor and directly nulling the recall for documents without predicted labels.