### PR TITLE
Refactor and add unit tests for rest and label calibration

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,9 +15,9 @@ authors:
     affiliation: "ZBW - Leibniz Information Centre for Economics"
 title: "qualle (a framework to predict the quality of a multi-label classification result)"
 abstract: "This framework allows to train a model which can be used to predict the quality of the result of applying a multi-label classification (MLC) method on a document. In this implementation, only the recall is predicted for a document, but in principle any document-level quality estimation (such as the prediction of precision) can be implemented analogously."
-version: 0.4.0
+version: 0.4.1
 license: Apache-2.0
-date-released: 2025-02-19
+date-released: 2025-03-27
 repository-code: "https://github.com/zbw/qualle"
 contact:
   - name: "Automatization of subject indexing using methods from artificial intelligence (AutoSE)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualle"
-version = "0.4.0-dev"
+version = "0.4.1-dev"
 description = "A framework to predict the quality of a multi-label classification result"
 authors = ["AutoSE <autose@zbw.eu>"]
 license = "Apache-2.0"

--- a/tests/features/label_calibration/test_thesauri_label_calibration/common.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/common.py
@@ -15,13 +15,16 @@ from rdflib import URIRef
 
 DUMMY_SUBTHESAURUS_TYPE = URIRef("http://type/Thsys")
 DUMMY_CONCEPT_TYPE = URIRef("http://type/Descriptor")
+DUMMY_UNKNOWN_TYPE = URIRef("http://type/Unknown")
 
 SUBTHESAURUS_A = URIRef("http://thsys/A")
 SUBTHESAURUS_B = URIRef("http://thsys/B")
 SUBTHESAURUS_C = URIRef("http://thsys/C")
+SUBTHESAURUS_D = URIRef("http://thsys/D")
 
 CONCEPT_URI_PREFIX = "http://concept"
 CONCEPT_x0 = "x0"
 CONCEPT_x1 = "x1"
 CONCEPT_x2 = "x2"
 CONCEPT_INVALID = "invalid"
+CONCEPT_UNKOWN = "unknown"

--- a/tests/features/label_calibration/test_thesauri_label_calibration/conftest.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/conftest.py
@@ -27,12 +27,15 @@ def graph():
     c_x0 = URIRef(f"{c.CONCEPT_URI_PREFIX}/{c.CONCEPT_x0}")
     c_x1 = URIRef(f"{c.CONCEPT_URI_PREFIX}/{c.CONCEPT_x1}")
     c_x2 = URIRef(f"{c.CONCEPT_URI_PREFIX}/{c.CONCEPT_x2}")
+    c_unkown = URIRef(f"{c.CONCEPT_URI_PREFIX}/{c.CONCEPT_UNKOWN}")
 
     g = Graph()
     for s in (c.SUBTHESAURUS_A, c.SUBTHESAURUS_B, c.SUBTHESAURUS_C):
         g.add((s, RDF.type, c.DUMMY_SUBTHESAURUS_TYPE))
     for concept in (c_x0, c_x1, c_x2):
         g.add((concept, RDF.type, c.DUMMY_CONCEPT_TYPE))
+
+    g.add((c_unkown, RDF.type, c.DUMMY_UNKNOWN_TYPE))
 
     g.add(
         (
@@ -75,6 +78,13 @@ def graph():
             c.SUBTHESAURUS_C,
             SKOS.narrower,
             c_x2,
+        )
+    )
+    g.add(
+        (
+            c.SUBTHESAURUS_D,
+            SKOS.narrower,
+            c_unkown,
         )
     )
     return g

--- a/tests/features/label_calibration/test_thesauri_label_calibration/test_thesaurus.py
+++ b/tests/features/label_calibration/test_thesauri_label_calibration/test_thesaurus.py
@@ -16,9 +16,10 @@ from rdflib import URIRef, Graph
 
 from qualle.features.label_calibration.thesauri_label_calibration import Thesaurus
 from tests.features.label_calibration.test_thesauri_label_calibration import common as c
+import logging
 
 
-def test_get_concepts_for_thesaurus(thesaurus):
+def test_get_concepts_for_thesaurus(thesaurus, caplog):
     concepts = thesaurus.get_concepts_for_subthesaurus(c.SUBTHESAURUS_A)
     assert concepts == {c.CONCEPT_x0, c.CONCEPT_x1, c.CONCEPT_x2}
 
@@ -27,6 +28,14 @@ def test_get_concepts_for_thesaurus(thesaurus):
 
     concepts = thesaurus.get_concepts_for_subthesaurus(c.SUBTHESAURUS_C)
     assert concepts == {c.CONCEPT_x2}
+
+    caplog.set_level(logging.WARNING)
+    concepts = thesaurus.get_concepts_for_subthesaurus(c.SUBTHESAURUS_D)
+    assert concepts == set()
+    assert (
+        f"unknown narrower type {c.CONCEPT_URI_PREFIX}/{c.CONCEPT_UNKOWN}"
+        in caplog.text
+    )
 
 
 def test_get_concepts_for_thesaurus_not_found_returns_empty(thesaurus):

--- a/tests/interface/test_rest.py
+++ b/tests/interface/test_rest.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
-
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -28,7 +27,9 @@ from qualle.interface.rest import (
     create_app,
     PREDICT_ENDPOINT,
     run,
+    load_model,
 )
+from pathlib import Path
 
 
 @pytest.fixture
@@ -62,6 +63,21 @@ def documents(train_data):
             for idx in range(len(p_data.docs))
         ]
     )
+
+
+def test_load_model(mocker, mdl_path):
+    m_pipe = mocker.Mock()
+    m_load_model = mocker.Mock(return_value=m_pipe)
+
+    mock_settings = mocker.patch("qualle.interface.rest.RESTSettings")
+    mock_settings.return_value.mdl_file = mdl_path
+
+    mocker.patch("qualle.interface.rest.internal_load_model", m_load_model)
+
+    qe_pipe = load_model()
+    assert qe_pipe == m_pipe
+    called_path = m_load_model.call_args[0][0]
+    assert Path(called_path) == mdl_path
 
 
 def test_return_http_200_for_predict(client, documents):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -36,6 +36,7 @@ def evaluator(train_data):
     return Evaluator(train_data, qe_p)
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in divide:RuntimeWarning")
 def test_evaluate_returns_scores(evaluator):
     scores = evaluator.evaluate()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,6 +60,7 @@ def test_train_stores_model(train_data_file, mdl_path):
     assert mdl_path.is_file()
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in divide:RuntimeWarning")
 def test_eval_prints_scores(train_data_file, mdl_path, caplog):
     caplog.set_level(logging.INFO)
 


### PR DESCRIPTION
Relevant issue: #40 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- The `load_model()` method inside `qualle/interface/rest.py` has no corresponding unit test. A new unit test should be included.
- The `else` statement inside the `get_concepts_for_subthesaurus()` method found in `qualle/features/label_calibration/thesauri_label_calibration.py` is not being considered in our existing unit tests. This should be remedied.
- In the most recent release of `qualle` the version and release-date were not updated inside the `pyproject.toml` file and `CITATION.cff` files. This info should be updated.


Changes introduced: `# list changes to the code repo made in this pull request`

- A new unit test has been added for `load_model()`.
- A new case has been inserted inside the unit test `test_get_concepts_for_thesaurus()` found in `tests/features/label_calibration/test_thesauri_label_calibration.py`. Some additions had to be introduced inside the `common.py` and `conftest.py` files located in the very same folder.
- The version and release-date of `qualle` have been updated to match the most recent release. The values inside `pyproject.toml` file and `CITATION.cff` file were bumped.
- `pytest` filter warnings decorator has been added to filter `RuntimeWarning` associated with two unit tests that are deliberately using `nan` values. This point was also mentioned in pull request #31 .
