### PR TITLE
Run command inside Dockerfile as JSONArgs to avoid warnings.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN poetry install --without dev,ci \
 	&& pip uninstall -y poetry \
 	&& rm -rf /root/.cache/pypoetry
 
-CMD gunicorn "qualle.interface.rest:create_app()"  -b 0.0.0.0 -k "uvicorn.workers.UvicornWorker"
+CMD ["gunicorn", "qualle.interface.rest:create_app()", "-b", "0.0.0.0", "-k", "uvicorn.workers.UvicornWorker"]


### PR DESCRIPTION
Relevant issue: #51 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- Building the image for `qualle` via the provided `Dockerfile` in the repo is a 7 stage process.
- The final stage executes a `CMD` command. 
- It throws a warning and gives a prompt of "JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals" before completing the final step.
- We should provide the arguments being fed to `CMD` as JSONArgs as given here: https://docs.docker.com/reference/build-checks/json-args-recommended/


Changes introduced: `# list changes to the code repo made in this pull request`

- The arguments provided inside the final line of the `Dockerfile` are now given as JSONArgs.
- The image has been built locally and tested with the new modified `Dockerfile`. Everything worked smoothly. 
