### PR TITLE
Update the github workflow files 

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -6,18 +6,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+       contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -64,7 +64,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
         if: matrix.python-version == '3.10'
 
       - name: Look for security vulnerabilities in dependencies

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -61,7 +61,7 @@ jobs:
         run: poetry run pytest --cov=qualle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.python-version == '3.10'

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -61,7 +61,7 @@ jobs:
         run: poetry run pytest --cov=qualle --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.python-version == '3.10'

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -10,15 +10,17 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: '3.10'
           cache: 'poetry'
@@ -38,18 +40,21 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -64,6 +64,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
         if: matrix.python-version == '3.10'
 
       - name: Look for security vulnerabilities in dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: '3.10'
           cache: 'poetry'
@@ -33,15 +35,17 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: '3.10'
 
@@ -67,10 +71,10 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -78,12 +82,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Relevant issue: #55 

Background info: `# any relevant background info for additional context, references to documentations etc.`

- Newer versions of several github actions are available. We should upgrade them.
- We should restrict the permission of job tokens and specify permissions on a job level.


Changes introduced: `# list changes to the code repo made in this pull request`

- `codecov`, `setup-python`, `checkout`, `docker/login`, `docker/metadata` and `docker/build-push`  are all `github` actions whose versions have been updated in the `.github/workflows` folder.
- The `permissions` keyword has been added on a job level to restrict the access granted to tokens.
