### PR TITLE
Fix deprecation warning in unit test

### DIFF
--- a/tests/interface/test_rest.py
+++ b/tests/interface/test_rest.py
@@ -90,7 +90,7 @@ def test_return_http_422_for_predict(client, documents):
     for doc in docs:
         del doc["predicted_labels"]
     resp = client.post(PREDICT_ENDPOINT, json=docs)
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_return_scores_for_predict(client, documents):


### PR DESCRIPTION
Relevant issue: #64 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- We receive a deprecation warning for one of our unit tests. We are importing the `status` module from `fastapi` but the status attribute `422` has changed
- The relevant status attribute in `fastapi` is given here: https://fastapi.tiangolo.com/reference/status/?h=http_422#fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT.
- We should replace  `HTTP_422_UNPROCESSABLE_ENTITY`  with `HTTP_422_UNPROCESSABLE_CONTENT` inside the unit test.


Changes introduced: `# list changes to the code repo made in this pull request`

- Added `status.HTTP_422_UNPROCESSABLE_CONTENT` inside the `assert` statement to avoid deprecation warnings from `test_rest.py`.
